### PR TITLE
publish release by tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
-# Python CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-python/ for more details
-#
 version: 2
+
 jobs:
   build:
     docker:
@@ -16,13 +13,6 @@ jobs:
       # - image: circleci/postgres:9.4
 
     working_directory: ~/repo
-    filters:
-      tags:
-        only:
-          - /^v.*/
-      branches:
-        only:
-          - master
 
     steps:
       - add_ssh_keys:
@@ -44,3 +34,20 @@ jobs:
           key: deps-{{ checksum "requirements.txt" }}
           paths:
             - ".venv"
+
+workflows:
+  version: 2
+  latest_builds:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: master
+  release_builds:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /v.*/
+            branches:
+              ignore: /.*/  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,13 @@ jobs:
       # - image: circleci/postgres:9.4
 
     working_directory: ~/repo
-    branches:
-      only:
-        - master
+    filters:
+      tags:
+        only:
+          - /^v.*/
+      branches:
+        only:
+          - master
 
     steps:
       - add_ssh_keys:

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -66,7 +66,12 @@ EOF
   git config --global user.name "circle-ci"
 
   # publish chart
-  chartpress --commit-range $CIRCLE_SHA1 --publish-chart
-
+  if [ -z "${CIRCLE_TAG+x}" ]; then
+    chartpress --commit-range $CIRCLE_SHA1 --publish-chart
+  else
+    # make a release by --tag
+    # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/CONTRIBUTING.md#push-built-images-to-dockerhub--bump-version
+    chartpress --tag $CIRCLE_TAG --publish-chart
+  fi
   popd
 }


### PR DESCRIPTION
introduce circleci's workflow to seperate a job into latest build and release build

* latest build only triggered by merging to master branch
* release build only triggered by `git tag` and the name starts with `v`