### PR TITLE
Remove Jupyter Admin from portal for model deployment only mode

### DIFF
--- a/chart/scripts/console/portal-config.yaml
+++ b/chart/scripts/console/portal-config.yaml
@@ -22,10 +22,12 @@ services:
     image: "/console/default-covers/support.png"
     target: "_blank"
   {{- end }}
+  {{- if or (eq .Values.primehub.mode "ee") (eq .Values.primehub.mode "ce") }}
   - name: JupyterHub Admin
     uri: "/hub/admin"
     adminOnly: true
     image: "/console/default-covers/jh-admin.png"
+  {{- end }}
   - name: Admin Dashboard
     uri: "/console/cms"
     image: "/console/default-covers/admin-ui.png"


### PR DESCRIPTION
Signed-off-by: popcorny <celu@infuseai.io>

Fix the portal in the model deployment only mode.

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
