### PR TITLE
Add fluentd to primehub chart

### DIFF
--- a/chart/images.txt
+++ b/chart/images.txt
@@ -19,3 +19,4 @@ infuseai/primehub-console-graphql:a81e94f0
 infuseai/primehub-console-watcher:a81e94f0
 infuseai/primehub-console-model-deploy:a81e94f0
 seldonio/seldon-core-executor:1.1.0
+fluent/fluentd-kubernetes-daemonset:v1.11-debian-s3-1

--- a/chart/templates/fluentd/configmap.yaml
+++ b/chart/templates/fluentd/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.fluentd.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -89,3 +90,4 @@ data:
         chunk_limit_size "#{ENV['BUFFER_CHUNK_LIMIT_SIZE']}"
       </buffer>
     </match>
+{{- end }}

--- a/chart/templates/fluentd/configmap.yaml
+++ b/chart/templates/fluentd/configmap.yaml
@@ -28,6 +28,7 @@ data:
     # we use kubernetes metadata plugin to add metadatas to the log
     <filter kubernetes.**>
       @type kubernetes_metadata
+      skip_namespace_metadata true
     </filter>
 
     # select pods from specific namespace

--- a/chart/templates/fluentd/configmap.yaml
+++ b/chart/templates/fluentd/configmap.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "primehub.name" . }}-fluentd
+data:
+  fluent.conf: |
+    <label @FLUENT_LOG>
+      <match fluent.**>
+        @type null
+      </match>
+    </label>
+
+    # here we read the logs from Docker's containers and parse them
+    <source>
+      @type tail
+      @id in_tail_container_logs
+      path /var/log/containers/*.log
+      pos_file /var/log/primehub-fluentd-containers.log.pos
+      tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
+      exclude_path "#{ENV['FLUENT_CONTAINER_TAIL_EXCLUDE_PATH'] || use_default}"
+      read_from_head true
+      <parse>
+        @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </parse>
+    </source>
+
+    # we use kubernetes metadata plugin to add metadatas to the log
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+    </filter>
+
+    # select pods from specific namespace
+    <filter kubernetes.**>
+        @type grep
+        <regexp>
+            key $.kubernetes.namespace_name
+            pattern hub
+        </regexp>
+    </filter>
+
+    <filter kubernetes.**>
+      @type record_transformer
+      enable_ruby
+      <record>
+        namespace ${record.dig("kubernetes", "namespace_name")}
+        pod ${record.dig("kubernetes", "pod_name")}
+        container ${record.dig("kubernetes", "container_name")}
+      </record>
+    </filter>
+
+    <match kubernetes.**>
+      @type rewrite_tag_filter
+      <rule>
+        key     $.kubernetes.labels.app
+        pattern /^primehub-job$/
+        tag     phjob
+      </rule>
+    </match>
+
+    # PhJobs
+    <match phjob>
+      # docs: https://docs.fluentd.org/v0.12/articles/out_s3
+      # note: this configuration relies on the nodes have an IAM instance profile with access to your S3 bucket
+      @type s3
+      @id out_s3
+      @log_level info
+      s3_bucket "#{ENV['S3_BUCKET_NAME']}"
+      s3_endpoint "#{ENV['S3_ENDPOINT']}"
+      path logs/phjob/${pod}/%Y%m%d
+      s3_object_key_format %{path}/log-%{index}.%{file_extension}
+      force_path_style true
+      store_as txt
+      <format>
+        @type single_value
+        message_key log
+        add_newline false
+      </format>
+      <buffer namespace, pod, container, time>
+        @type file
+        path /var/log/fluentd-buffers/primehub/${namespace}/${pod}/${container}
+        flush_mode interval
+        flush_interval 10
+        timekey 86400
+        timekey_wait 60
+        timekey_use_utc true
+        chunk_limit_size 256m
+      </buffer>
+    </match>

--- a/chart/templates/fluentd/configmap.yaml
+++ b/chart/templates/fluentd/configmap.yaml
@@ -71,7 +71,7 @@ data:
       path logs/phjob/${pod}/%Y%m%d
       s3_object_key_format %{path}/log-%{index}.%{file_extension}
       force_path_style true
-      store_as txt
+      store_as "#{ENV['S3_STORE_AS']}"
       <format>
         @type single_value
         message_key log
@@ -80,11 +80,12 @@ data:
       <buffer namespace, pod, container, time>
         @type file
         path /var/log/fluentd-buffers/primehub/${namespace}/${pod}/${container}
+        flush_at_shutdown "#{ENV['BUFFER_FLUSH_AT_SHUTDOWN']}"
         flush_mode interval
-        flush_interval 10
+        flush_interval "#{ENV['BUFFER_FLUSH_INTERVAL']}"
         timekey 86400
         timekey_wait 60
         timekey_use_utc true
-        chunk_limit_size 256m
+        chunk_limit_size "#{ENV['BUFFER_CHUNK_LIMIT_SIZE']}"
       </buffer>
     </match>

--- a/chart/templates/fluentd/daemonset.yaml
+++ b/chart/templates/fluentd/daemonset.yaml
@@ -1,0 +1,76 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ include "primehub.name" . }}-fluentd
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        checksum/config-map: {{ include (print .Template.BasePath "/fluentd/configmap.yaml") . | sha256sum }}
+        checksum/secret-map: {{ include (print .Template.BasePath "/fluentd/secret.yaml") . | sha256sum }}
+    spec:
+      serviceAccount: {{ include "primehub.name" . }}-fluentd
+      serviceAccountName: {{ include "primehub.name" . }}-fluentd
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: fluentd
+        image: fluent/fluentd-kubernetes-daemonset:v1.11-debian-s3-1
+        env:
+        - name: FLUENT_UID
+          value: "0"
+        - name:  S3_BUCKET_NAME
+          value: "primehub"
+        - name:  S3_BUCKET_REGION
+          value: "us-east-1"
+        - name:  S3_ENDPOINT
+          value: "http://minio.hub:9000/"
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "primehub.name" . }}-fluentd
+              key: aws_access_key_id
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "primehub.name" . }}-fluentd
+              key: aws_secret_access_key
+        resources: {}
+        #  limits:
+        #    memory: 200Mi
+        #  requests:
+        #    cpu: 100m
+        #    memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluentd-etc-volume
+          mountPath: /fluentd/etc/fluent.conf
+          subPath: fluent.conf
+          readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluentd-etc-volume
+        configMap:
+          name: {{ include "primehub.name" . }}-fluentd

--- a/chart/templates/fluentd/daemonset.yaml
+++ b/chart/templates/fluentd/daemonset.yaml
@@ -3,40 +3,66 @@ kind: DaemonSet
 metadata:
   name: {{ include "primehub.name" . }}-fluentd
   labels:
-    k8s-app: fluentd-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
+    app.kubernetes.io/name: {{ include "primehub.name" . }}-fluentd
+    helm.sh/chart: {{ include "primehub.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "primehub.name" . }}-fluentd
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        k8s-app: fluentd-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
+        app.kubernetes.io/name: {{ include "primehub.name" . }}-fluentd
+        app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         checksum/config-map: {{ include (print .Template.BasePath "/fluentd/configmap.yaml") . | sha256sum }}
         checksum/secret-map: {{ include (print .Template.BasePath "/fluentd/secret.yaml") . | sha256sum }}
     spec:
       serviceAccount: {{ include "primehub.name" . }}-fluentd
       serviceAccountName: {{ include "primehub.name" . }}-fluentd
+      {{- with .Values.fluentd.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.fluentd.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.fluentd.tolerations }}
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      - key: "nvidia.com/gpu"
-        operator: "Exists"
-        effect: "NoSchedule"
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: fluentd
-        image: fluent/fluentd-kubernetes-daemonset:v1.11-debian-s3-1
+        image: "{{ .Values.fluentd.image.repository }}:{{ .Values.fluentd.image.tag }}"
+        imagePullPolicy: {{ .Values.fluentd.image.pullPolicy }}
         env:
         - name: FLUENT_UID
           value: "0"
         - name:  S3_BUCKET_NAME
-          value: "primehub"
+          value: "{{ .Values.fluentd.bucket }}"
         - name:  S3_BUCKET_REGION
           value: "us-east-1"
         - name:  S3_ENDPOINT
-          value: "http://minio.hub:9000/"
+          value: "{{ .Values.fluentd.endpoint }}"
+        - name:  S3_STORE_AS
+          value: "{{ .Values.fluentd.storeAs }}"
+        - name:  BUFFER_FLUSH_AT_SHUTDOWN
+          value: {{ .Values.fluentd.flushAtShutdown | quote}}
+        - name:  BUFFER_FLUSH_INTERVAL
+          value: {{ .Values.fluentd.flushInterval | quote}}
+        - name:  BUFFER_CHUNK_LIMIT_SIZE
+          value: {{ .Values.fluentd.chunkLimitSize | quote}}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -47,12 +73,8 @@ spec:
             secretKeyRef:
               name: {{ include "primehub.name" . }}-fluentd
               key: aws_secret_access_key
-        resources: {}
-        #  limits:
-        #    memory: 200Mi
-        #  requests:
-        #    cpu: 100m
-        #    memory: 200Mi
+        resources:
+          {{- toYaml .Values.fluentd.resources | nindent 10 }}
         volumeMounts:
         - name: varlog
           mountPath: /var/log
@@ -74,5 +96,3 @@ spec:
       - name: fluentd-etc-volume
         configMap:
           name: {{ include "primehub.name" . }}-fluentd
-  updateStrategy:
-    type: RollingUpdate

--- a/chart/templates/fluentd/daemonset.yaml
+++ b/chart/templates/fluentd/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.fluentd.enabled -}}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -96,3 +97,4 @@ spec:
       - name: fluentd-etc-volume
         configMap:
           name: {{ include "primehub.name" . }}-fluentd
+{{- end }}

--- a/chart/templates/fluentd/daemonset.yaml
+++ b/chart/templates/fluentd/daemonset.yaml
@@ -74,3 +74,5 @@ spec:
       - name: fluentd-etc-volume
         configMap:
           name: {{ include "primehub.name" . }}-fluentd
+  updateStrategy:
+    type: RollingUpdate

--- a/chart/templates/fluentd/rbac.yaml
+++ b/chart/templates/fluentd/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.fluentd.enabled -}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -33,3 +34,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "primehub.name" . }}-fluentd
   namespace: {{.Release.Namespace}}
+{{- end }}

--- a/chart/templates/fluentd/rbac.yaml
+++ b/chart/templates/fluentd/rbac.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "primehub.name" . }}-fluentd
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ include "primehub.name" . }}-fluentd
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ include "primehub.name" . }}-fluentd
+roleRef:
+  kind: ClusterRole
+  name: {{ include "primehub.name" . }}-fluentd
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "primehub.name" . }}-fluentd
+  namespace: {{.Release.Namespace}}

--- a/chart/templates/fluentd/secret.yaml
+++ b/chart/templates/fluentd/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "primehub.name" . }}-fluentd
+stringData:
+  aws_access_key_id: 'AKIAIOSFODNN7EXAMPLE'
+  aws_secret_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'

--- a/chart/templates/fluentd/secret.yaml
+++ b/chart/templates/fluentd/secret.yaml
@@ -3,5 +3,6 @@ kind: Secret
 metadata:
   name: {{ include "primehub.name" . }}-fluentd
 stringData:
+  # This is temporary secret. Will use the same secret in primehub store.
   aws_access_key_id: 'AKIAIOSFODNN7EXAMPLE'
   aws_secret_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'

--- a/chart/templates/fluentd/secret.yaml
+++ b/chart/templates/fluentd/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.fluentd.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ stringData:
   # This is temporary secret. Will use the same secret in primehub store.
   aws_access_key_id: 'AKIAIOSFODNN7EXAMPLE'
   aws_secret_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -576,3 +576,27 @@ istio:
     service:
       type: ClusterIP
       port: 8080
+
+fluentd:
+  enabled: false
+  image:
+    repository: infuseai/primehub-console-graphql
+    tag: a81e94f0
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 3001
+  resources:
+    # limits:
+    #   cpu: 512m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 512Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -580,7 +580,6 @@ istio:
 fluentd:
   enabled: false
 
-
   # Buffer configuration: https://docs.fluentd.org/configuration/buffer-section
   flushAtShutdown: false
   flushInterval: "3600s"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -579,21 +579,28 @@ istio:
 
 fluentd:
   enabled: false
+
+
+  # Buffer configuration: https://docs.fluentd.org/configuration/buffer-section
+  flushAtShutdown: false
+  flushInterval: "3600s"
+  chunkLimitSize: "256m"
+  # XXX: will be removed when integration with primehub store
+  bucket: "primehub"
+  endpoint: "http://minio.hub:9000/"
+  # S3 Configuratio
+  storeAs: "txt"
   image:
-    repository: infuseai/primehub-console-graphql
-    tag: a81e94f0
+    repository: fluent/fluentd-kubernetes-daemonset
+    tag: v1.11-debian-s3-1
     pullPolicy: IfNotPresent
-  service:
-    type: ClusterIP
-    port: 80
-    targetPort: 3001
   resources:
-    # limits:
-    #   cpu: 512m
-    #   memory: 512Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 512Mi
+    limits:
+      cpu: 512m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 512Mi
 
   nodeSelector: {}
 


### PR DESCRIPTION
# Introduction
https://app.clubhouse.io/infuseai/story/8830/job-submission-persistence-log-setup-the-fluentd-for-collecting-primehub-logs


# Setup environment
1. install minio

    ```
    helm upgrade --install minio stable/minio --namespace hub 
    ```

2. login to minio

    ```
    kubectl -n hub port-forward service/minio 9000     
    ```

3. login to minio. Go to http://localhost:9000/minio/

    accesskey: `AKIAIOSFODNN7EXAMPLE`
    secretkey: `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`

4. Create a bucket `primehub`
