### PR TITLE
Fix DaemonSet version

### DIFF
--- a/chart/templates/fluentd/daemonset.yaml
+++ b/chart/templates/fluentd/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if eq (include "fluentd.enabled" .) "true" -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "primehub.name" . }}-fluentd


### PR DESCRIPTION
** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Fix api version

**What this PR does / why we need it**:

Make it compatible with k8s 1.16+

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md#deprecations

> DaemonSet, Deployment, and ReplicaSet resources will no longer be served from extensions/v1beta1, apps/v1beta1, or apps/v1beta2 in v1.16. Migrate to the apps/v1 API, available since v1.9. Existing persisted data can be retrieved via the apps/v1 API.