### PR TITLE
[Cherrypick 2.8] Fix env dataset for bash

### DIFF
--- a/chart/scripts/jupyterhub/config/jupyterhub_profiles.py
+++ b/chart/scripts/jupyterhub/config/jupyterhub_profiles.py
@@ -349,7 +349,10 @@ class OIDCAuthenticator(GenericOAuthenticator):
                         "[%s] is a invalid env key. Discarded" %
                         env_key)
                     continue
+                # For backward compatibility in env
                 ds_env[env_key] = value
+                # Actually, hyphen is not supported in bash
+                ds_env[env_key.replace('-', '_')] = value
 
             spawner.environment.update(ds_env)
         else:


### PR DESCRIPTION
Cherrypick
https://app.clubhouse.io/infuseai/story/11389/bug-env-dataset-will-contain-invalid-character-hyphen-if-the-dataset-name-include-hyphen