### PR TITLE
Prevent ensure_sshd from blocking start-notebook.d

### DIFF
--- a/chart/scripts/start-notebook.d/ensure_sshd.sh
+++ b/chart/scripts/start-notebook.d/ensure_sshd.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-if [ "$PRIMEHUB_START_SSH" == "true" ]; then
-
+ensure_sshd() {
     # Check installed sshd
     if command -v sshd &>/dev/null; then
         echo "Starting sshd"
@@ -27,6 +26,10 @@ if [ "$PRIMEHUB_START_SSH" == "true" ]; then
             echo "No permission to install sshd"
         fi
     fi
+}
+
+if [ "$START_SSH" == "true" ]; then
+    ensure_sshd &
 
     # Start publickey api server
     if command -v nohup &>/dev/null; then


### PR DESCRIPTION
Signed-off-by: Ash Wu <hSATAC@gmail.com>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Fix apt-get may block notebook from starting due to internet connectivity.

