### PR TITLE
[Feature] change groupvolume nfs to use default storageclass

### DIFF
--- a/chart/hooks/groupvolume/nfs-for-pvc.jsonnet
+++ b/chart/hooks/groupvolume/nfs-for-pvc.jsonnet
@@ -2,9 +2,16 @@ function(request) {
   local pvc = request.object,
   local annotations = pvc.metadata.annotations,
   local group = annotations["primehub-group"],
-  local rwo_sc = if std.objectHas(annotations, "primehub-group-sc")
-    then annotations["primehub-group-sc"]
-    else "rook-block",
+  local pvc_spec = if std.objectHas(annotations, "primehub-group-sc")
+    then {
+      accessModes: [ "ReadWriteOnce" ],
+      storageClassName: annotations["primehub-group-sc"],
+      resources: pvc.spec.resources
+    }
+    else {
+      accessModes: [ "ReadWriteOnce" ],
+      resources: pvc.spec.resources
+    },
   local mount_options = if std.objectHas(annotations, "primehub-group-mount-options")
     then annotations["primehub-group-mount-options"]
     else "nfsvers=4.1",
@@ -120,11 +127,7 @@ function(request) {
             metadata: {
               name: "data"
             },
-            spec: {
-              accessModes: [ "ReadWriteOnce" ],
-              storageClassName: rwo_sc,
-              resources: pvc.spec.resources
-            }
+            spec: pvc_spec
           }
         ]
       }


### PR DESCRIPTION
Co-authored-by: Kent Huang <kentwelcome@gmail.com>
Co-authored-by: Aaron Huang <aaroms9733@gmail.com>

Signed-off-by: Kent Huang <kentwelcome@gmail.com>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Let primehub-groupvolume support k8s default storage class

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
