### PR TITLE
[Feature] ch11353 auto gen some secret if not provided  

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,55 +6,21 @@ Prepare the value file `primehub-values.yaml` for helm installation.
 Key | Description
 ----|------------------------------------
 `PRIMEHUB_DOMAIN` | The domain name of primehub. It can be the same as primehub's one.
-`PRIMEHUB_PASSWORD` | The password for primehub admin. (The default username of admin is `phadmin`)
-`KEYCLOAK_PASSWORD` | The master password of keycloak
-`STORAGE_CLASS` | The storage class for persistence storage
-`GRAPHQL_SECRET_KEY` | The graphql API secret key
-`HUB_AUTH_STATE_CRYPTO_KEY` | The jupyterhub crypo key. Please reference the [z2jh document](https://zero-to-jupyterhub.readthedocs.io/en/latest/reference/reference.html#auth-state-cryptokey).
-`HUB_PROXY_SECRET_TOKEN` | The jupyterhub secret. Please reference the [z2jh document](https://zero-to-jupyterhub.readthedocs.io/en/latest/reference/reference.html#proxy-secrettoken).
 
 Modify the environment variables below and execute the commands to generate the value file.
 
 ```
 PRIMEHUB_DOMAIN=1.2.3.4.nip.io
-PRIMEHUB_PASSWORD=__my_password__
-KEYCLOAK_PASSWORD=__my_password__
-STORAGE_CLASS=__storage_class__
-GRAPHQL_SECRET_KEY=$(openssl rand -hex 32)
-HUB_AUTH_STATE_CRYPTO_KEY=$(openssl rand -hex 32)
-HUB_PROXY_SECRET_TOKEN=$(openssl rand -hex 32)
 
 cat <<EOF > primehub-values.yaml
 primehub:
   domain: ${PRIMEHUB_DOMAIN}
-keycloak:
-  password: ${KEYCLOAK_PASSWORD}
-bootstrap:
-  password: ${PRIMEHUB_PASSWORD}
-graphql:
-  sharedGraphqlSecret: ${GRAPHQL_SECRET_KEY}
-groupvolume:
-  storageClass: ${STORAGE_CLASS}
 ingress:
   annotations:
     kubernetes.io/ingress.allow-http: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
   hosts:
   -  ${PRIMEHUB_DOMAIN}
-jupyterhub:
-  auth:
-    state:
-      cryptoKey: ${GRAPHQL_SECRET_KEY}
-  hub:
-    db:
-      pvc:
-        storageClassName: ${STORAGE_CLASS}
-  proxy:
-    secretToken: ${HUB_PROXY_SECRET_TOKEN}
-  singleuser:
-    storage:
-      dynamic:
-        storageClass: ${STORAGE_CLASS}
 EOF
 ```
 

--- a/chart/scripts/jupyterhub/config/jupyterhub_profiles.py
+++ b/chart/scripts/jupyterhub/config/jupyterhub_profiles.py
@@ -51,7 +51,7 @@ if role_prefix:
     role_prefix += ':'
 
 graphql_endpoint = get_primehub_config('graphqlEndpoint')
-graphql_secret = get_primehub_config('graphqlSecret')
+graphql_secret = os.environ.get('GRAPHQL_SHARED_SECRET', get_primehub_config('graphqlSecret'))
 fs_group_id = get_config('singleuser.fsGid')
 
 autoscaling_enabled = get_config('scheduling.userScheduler.enabled')

--- a/chart/templates/admission/webhook-deploy.yaml
+++ b/chart/templates/admission/webhook-deploy.yaml
@@ -31,7 +31,10 @@ spec:
         - name: GRAPHQL_ENDPOINT
           value: {{ include "primehub.graphql.endpoint" . }}
         - name: GRAPHQL_SHARED_SECRET
-          value: {{ .Values.graphql.sharedGraphqlSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "primehub.name" . }}-graphql
+              key: sharedSecret
         - name: FLASK_DEBUG
           value: "false"
         - name: LOGURU_LEVEL

--- a/chart/templates/bootstrap/job.yaml
+++ b/chart/templates/bootstrap/job.yaml
@@ -43,8 +43,13 @@ spec:
           - name: KC_PASSWORD
             valueFrom:
               secretKeyRef:
+            {{- if .Values.keycloak.deploy }}
+                name: {{ include "keycloak.fullname" . }}-http
+                key: {{ include "keycloak.passwordKey" . }}
+            {{- else }}
                 name: "primehub-bootstrap"
                 key: kcpassword
+            {{- end }}
           - name: KC_REALM
             value: {{ .Values.primehub.keycloak.realm }}
           {{- if (eq .Values.primehub.keycloak.scheme "http") }}

--- a/chart/templates/bootstrap/secret.yaml
+++ b/chart/templates/bootstrap/secret.yaml
@@ -2,8 +2,14 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "primehub-bootstrap"
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/resource-policy: keep
 type: Opaque
 data:
+# Keycloak
+{{- if not .Values.keycloak.deploy }}
   kcpassword: {{ include "primehub.keycloak.password" . | default "" | b64enc }}
+{{- end}}
   password: {{ .Values.bootstrap.password | default "" | b64enc }}
 

--- a/chart/templates/bootstrap/secret.yaml
+++ b/chart/templates/bootstrap/secret.yaml
@@ -5,11 +5,13 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
 # Keycloak
 {{- if not .Values.keycloak.deploy }}
   kcpassword: {{ include "primehub.keycloak.password" . | default "" | b64enc }}
 {{- end}}
-  password: {{ .Values.bootstrap.password | default "" | b64enc }}
+  password: {{ .Values.bootstrap.password | default (randAlphaNum 16) | b64enc }}
 

--- a/chart/templates/controller/configmap.yaml
+++ b/chart/templates/controller/configmap.yaml
@@ -18,8 +18,6 @@ data:
 {{ toYaml .Values.customImage | indent 6 }}
     jobSubmission:
 {{ toYaml .Values.jobSubmission | indent 6 }}
-      graphqlEndpoint: {{ include "primehub.graphql.endpoint" . }}
-      graphqlSecret: {{ .Values.graphql.sharedGraphqlSecret }}
       phfsEnabled: {{ include "primehub.phfs.enabled" . }}
       phfsPVC: {{ include "primehub.store.pvcName" . }}
     modelDeployment:

--- a/chart/templates/controller/deployment.yaml
+++ b/chart/templates/controller/deployment.yaml
@@ -49,6 +49,13 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: JOBSUBMISSION_GRAPHQLENDPOINT
+            value: {{ include "primehub.graphql.endpoint" . }}
+          - name: JOBSUBMISSION_GRAPHQLSECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "primehub.name" . }}-graphql
+                key: sharedSecret
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
           volumeMounts:

--- a/chart/templates/graphql/secret.yaml
+++ b/chart/templates/graphql/secret.yaml
@@ -29,4 +29,6 @@ metadata:
     helm.sh/hook: pre-install
     helm.sh/resource-policy: keep
     {{- end }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque

--- a/chart/templates/graphql/secret.yaml
+++ b/chart/templates/graphql/secret.yaml
@@ -12,6 +12,8 @@ apiVersion: v1
 data:
 {{- if .Values.graphql.sharedGraphqlSecret }}
   sharedSecret: {{ .Values.graphql.sharedGraphqlSecret | b64enc }}
+{{- else }}
+  sharedSecret: {{ randAlphaNum 32 | b64enc }}
 {{- end }}
 {{- if .Values.store.enabled }}
   storeAccessKey: {{ include "primehub.store.accessKey" . | b64enc }}
@@ -20,4 +22,11 @@ data:
 kind: Secret
 metadata:
   name: {{ include "primehub.name" . }}-graphql
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+    {{- if not .Values.graphql.sharedGraphqlSecret }}
+    helm.sh/hook: pre-install
+    helm.sh/resource-policy: keep
+    {{- end }}
 type: Opaque

--- a/chart/templates/jupyterhub/configmap.yaml
+++ b/chart/templates/jupyterhub/configmap.yaml
@@ -41,7 +41,6 @@ data:
     baseUrl: /
     version: {{ .Chart.AppVersion | quote }}
     graphqlEndpoint: {{ include "primehub.graphql.endpoint" . }}
-    graphqlSecret: {{ .Values.graphql.sharedGraphqlSecret }}
     phfsEnabled: {{ include "primehub.phfs.enabled" . }}
     phfsPVC: {{ include "primehub.store.pvcName" . }}
     keycloak:

--- a/chart/templates/keycloak/postgresql/secrets.yaml
+++ b/chart/templates/keycloak/postgresql/secrets.yaml
@@ -16,6 +16,7 @@ metadata:
     chart: {{ template "primehub.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   postgresql-password: {{ include "postgresql.password" . | b64enc | quote }}

--- a/chart/templates/keycloak/postgresql/secrets.yaml
+++ b/chart/templates/keycloak/postgresql/secrets.yaml
@@ -4,6 +4,13 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "postgresql.fullname" . }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+    {{- if not .Values.keycloak.postgresql.postgresqlPassword }}
+    helm.sh/hook: pre-install
+    helm.sh/resource-policy: keep
+    {{- end }}
   labels:
     app: {{ template "postgresql.name" . }}
     chart: {{ template "primehub.chart" . }}

--- a/chart/templates/keycloak/secret-keycloak.yaml
+++ b/chart/templates/keycloak/secret-keycloak.yaml
@@ -4,6 +4,13 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "keycloak.fullname" . }}-http
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+    {{- if not .Values.keycloak.password }}
+    helm.sh/hook: pre-install
+    helm.sh/resource-policy: keep
+    {{- end }}
   labels:
     {{- include "keycloak.commonLabels" . | nindent 4 }}
 type: Opaque

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -455,6 +455,11 @@ jupyterhub:
           secretKeyRef:
             name: primehub-client-jupyterhub
             key: client_secret
+      - name: GRAPHQL_SHARED_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: primehub-graphql
+            key: sharedSecret
     extraContainers: []
     extraVolumes:
     - name: primehub-hub-images

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -498,12 +498,6 @@ jupyterhub:
       tag: jh-5c94e4f4
     networkPolicy:
       enabled: true
-    extraEnv:
-      - name: KC_CLIENT_SECRET
-        valueFrom:
-          secretKeyRef:
-            key: client_secret
-            name: primehub-client-jupyterhub
     extraConfig:
       primehub_config_main.py: |
         exec(open("/srv/primehub/primehub_config.py").read())


### PR DESCRIPTION
The following 6 secrets will be auto-generated if not provided

- GRAPHQL_SECRET_KEY -> chart/templates/graphql/secret.yaml
- HUB_AUTH_STATE_CRYPTO_KEY -> chart/charts/jupyterhub/templates/hub/secret.yaml
- HUB_PROXY_SECRET_TOKEN -> chart/charts/jupyterhub/templates/hub/secret.yaml
- KC_PASSWORD -> chart/templates/keycloak/secret-keycloak.yaml
- PH_PASSWORD -> chart/templates/bootstrap/secret.yaml
- KC_DB_PASSWORD -> chart/templates/keycloak/postgresql/secrets.yaml

Co-authored-by: Kent Huang <kentwelcome@gmail.com>
Co-authored-by: Ash Wu <hsatac@gmail.com>
Co-authored-by: Timothy Lee <ctiml@infuseai.io>

Signed-off-by: Kent Huang <kentwelcome@gmail.com>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] update submodule of zero-to-jupyterhub-k8s, after [PR#4](https://github.com/InfuseAI/zero-to-jupyterhub-k8s/pull/4)  merged

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
