### PR TITLE
Fix the redirection of the spawn pending page

### DIFF
--- a/chart/scripts/jupyterhub/config/jupyterhub_profiles.py
+++ b/chart/scripts/jupyterhub/config/jupyterhub_profiles.py
@@ -990,6 +990,10 @@ class PrimeHubHomeHandler(BaseHandler):
         group = self.get_query_argument("group", default=None)
         if user.spawner:
             user.spawner.set_active_group(group)
+            # If it is spawning, show the spawn pending page.
+            if user.spawner.pending == 'spawn':
+                self.redirect(url)
+                return
 
         html = self.render_template(
             'home.html',

--- a/chart/scripts/jupyterhub/theme/templates/page.html
+++ b/chart/scripts/jupyterhub/theme/templates/page.html
@@ -40,7 +40,10 @@
 {{ super() }}
 <script>
   // In non in embedded mode, always go back to primehub console
-  if (window.self === window.top) {
+  // (except spawn-pending page, please see ch12374)
+  if (window.self === window.top &&
+      !window.location.pathname.startsWith('/hub/spawn-pending'))
+  {
     {% if user.spawner and user.spawner.launch_group %}
     window.top.location = '/console/g/{{ user.spawner.launch_group }}/hub';
     {% else %}


### PR DESCRIPTION
Cherry pick ch12374
https://app.clubhouse.io/infuseai/story/12374/bug-when-user-is-spawning-a-jupyter-pod-and-user-clicks-my-server-in-jupyterhub-page-he-will-see-the-spawning-status-without