### PR TITLE
Parameterize probe timeout seconds for graphql

### DIFF
--- a/chart/templates/graphql/deployment.yaml
+++ b/chart/templates/graphql/deployment.yaml
@@ -186,12 +186,18 @@ spec:
           livenessProbe:
             initialDelaySeconds: 60
             periodSeconds: 5
+            {{- if .Values.graphql.probe.timeoutSeconds }}
+            timeoutSeconds: {{ .Values.graphql.probe.timeoutSeconds }}
+            {{- end }}
             httpGet:
               port: http
               path: {{ include "primehub.graphql.path" . }}/health
           readinessProbe:
             initialDelaySeconds: 10
             periodSeconds: 10
+            {{- if .Values.graphql.probe.timeoutSeconds }}
+            timeoutSeconds: {{ .Values.graphql.probe.timeoutSeconds }}
+            {{- end }}
             httpGet:
               port: http
               path: {{ include "primehub.graphql.path" . }}/health

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -354,6 +354,8 @@ graphql:
     requests:
       cpu: 100m
       memory: 512Mi
+  probe: {}
+  #  timeoutSeconds: 1
 
   nodeSelector: {}
 


### PR DESCRIPTION
Signed-off-by: Timothy Lee <ctiml@infuseai.io>
Co-authored-by: Kent Huang <kent@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:
Make timeout seconds of graphql probe configurable

**Which issue(s) this PR fixes**:
https://app.clubhouse.io/infuseai/story/13382/primehub-graphql-can-configure-liveness-and-readness-timeout-second-by-helm-value

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
