### PR TITLE
Add default tolerations to primehub-store's daemonset

### DIFF
--- a/chart/templates/fluentd/daemonset.yaml
+++ b/chart/templates/fluentd/daemonset.yaml
@@ -34,13 +34,13 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.fluentd.tolerations }}
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
         - key: "nvidia.com/gpu"
           operator: "Exists"
           effect: "NoSchedule"
+      {{- with .Values.fluentd.tolerations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/chart/templates/rclone/csi-nodeplugin-rclone.yaml
+++ b/chart/templates/rclone/csi-nodeplugin-rclone.yaml
@@ -77,8 +77,10 @@ spec:
           resources:
             {{ .Values.rclone.rclone.resources | toYaml | indent 12 | trim }}
           {{- end }}
-      {{- with .Values.rclone.rclone.tolerations }}
       tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      {{- with .Values.rclone.rclone.tolerations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:


### PR DESCRIPTION
Signed-off-by: Ching Yi, Chan <qrtt1@infuseai.io>

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

bugfix

**What this PR does / why we need it**:

Add default tolerations to some DaemonSets

**Which issue(s) this PR fixes**:

ch13249

**Special notes for your reviewer**:

We do this before, it adds tolerations when there are values in the `.Values.rclone.rclone.tolerations` 

```yaml
      {{- with .Values.rclone.rclone.tolerations }}
      tolerations:
        - effect: NoSchedule
          operator: Exists
        {{- toYaml . | nindent 8 }}
      {{- end }}
```

If there are no values in `.Values.rclone.rclone.tolerations`, the default settings don't go with DaemonSet. We never see this configuration in the csi-nodeplugin-rclone or fluend DaemonSet

```yaml
      tolerations:
        - effect: NoSchedule
          operator: Exists
```