### PR TITLE
Add resource defaults to primehub-store

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -913,8 +913,12 @@ minio:
   affinity: {}
 
   resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
     requests:
-      memory: 512Mi
+      cpu: 150m
+      memory: 64Mi
 
   s3gateway:
     enabled: false
@@ -943,14 +947,26 @@ rclone:
       repository: quay.io/k8scsi/csi-node-driver-registrar
       tag: v1.1.0
       pullPolicy: IfNotPresent
-    resources: {}
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 16Mi
 
   rclone:
     image:
       repository: infuseai/csi-rclone
       tag: v1.2.7-rebuild
       pullPolicy: IfNotPresent
-    resources: {}
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 16Mi
     tolerations: []
 
   csiAttacher:
@@ -958,14 +974,26 @@ rclone:
       repository: quay.io/k8scsi/csi-attacher
       tag: v1.1.1
       pullPolicy: IfNotPresent
-    resources: {}
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 16Mi
 
   csiClusterDriverRegistrar:
     image:
       repository: quay.io/k8scsi/csi-cluster-driver-registrar
       tag: v1.0.1
       pullPolicy: IfNotPresent
-    resources: {}
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 16Mi
 
 sshBastionServer:
   enabled: true


### PR DESCRIPTION
** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

bugfix

**What this PR does / why we need it**:

add default resources settings to primehub-store

**Which issue(s) this PR fixes**:

ch13707

**Special notes for your reviewer**:

There are limits in the primehub's pods 

```
(base) ($ |microk8s:default)➜  tests git:(feature/ch13707/all-pods-should-have-cpu-memory-limits-job) ✗ ./99limit.sh
NAMESPACE       NAME                                                          MEMLIMITS           MEMREQUESTS      CPULIMITS        CPUQUESTS     STATUS
hub             admission-post-install-job-m8fg8                              128Mi               128Mi            200m             100m          Succeeded
hub             csi-controller-rclone-0                                       256Mi,256Mi,256Mi   16Mi,16Mi,16Mi   100m,100m,100m   50m,50m,50m   Running
hub             csi-nodeplugin-rclone-4xmdp                                   256Mi,256Mi         16Mi,16Mi        100m,100m        50m,50m       Running
hub             hub-85f8bfdbf6-vbp2f                                          256Mi,512Mi         256Mi,512Mi      50m,1            50m,100m      Running
hub             keycloak-0                                                    512Mi               64Mi             500m             50m           Running
hub             keycloak-postgres-0                                           256Mi               64Mi             500m             50m           Running
hub             metacontroller-0                                              128Mi               32Mi             50m              50m           Running
hub             pod-image-replacing-webhook-6c454695bb-vnrdm                  256Mi               128Mi            1                128m          Running
hub             primehub-admin-notebook-5f8c495f9b-5bmwd                      128Mi,64Mi          128Mi,64Mi       1,50m            100m,50m      Running
hub             primehub-bootstrap-ndp65                                      128Mi               128Mi            500m             50m           Succeeded
hub             primehub-console-644f58785b-r8j97                             128Mi,30Mi          128Mi,15Mi       100m,50m         100m,10m      Running
hub             primehub-controller-86665d688-m7jrt                           512Mi               20Mi             100m             100m          Running
hub             primehub-dataset-upload-5598fbc895-5twhr                      128Mi               128Mi            50m              50m           Running
hub             primehub-fluentd-n4t88                                        512Mi               512Mi            512m             100m          Running
hub             primehub-gitsync-67cddff4cd-hkfjf                             128Mi               128Mi            50m              50m           Running
hub             primehub-graphql-65b948c84f-plzn6                             512Mi,30Mi          512Mi,15Mi       1,50m            100m,10m      Running
hub             primehub-group-6968cd9b86-c7cmj                               128Mi               128Mi            50m              50m           Running
hub             primehub-minio-0                                              256Mi               64Mi             500m             150m          Running
hub             primehub-minio-make-bucket-job-fm226                          256Mi               64Mi             500m             150m          Succeeded
hub             primehub-usage-api-74f568f967-lwz9q                           256Mi               256Mi            250m             50m           Running
hub             primehub-usage-db-0                                           256Mi               256Mi            500m             50m           Running
hub             primehub-usage-prober-6d886799f-5b2qq                         256Mi               256Mi            250m             50m           Running
hub             primehub-usage-running-pods-monitor-ffc78dcdb-d7cnx           256Mi               128Mi            150m             50m           Running
hub             primehub-watcher-5d97b8646b-xch7q                             128Mi               128Mi            50m              50m           Running
hub             proxy-bcbbbb594-5lsrs                                         512Mi               512Mi            200m             200m          Running
hub             pvc-check-webhook-bb57fb4f9-9ng4q                             256Mi               128Mi            1                128m          Running
hub             resources-validation-webhook-cb86b9495-ht94b                  256Mi               128Mi            1                128m          Running
hub             ssh-bastion-server-76bbdc5cd8-6hxxn                           512Mi               256Mi            200m             100m          Running
hub             ssh-bastion-server-metacontroller-7c798bc6c7-528d6            128Mi               128Mi            50m              50m           Running
tests finished
```