### PR TITLE
[Fix] ch13416 hardcode jobLimit 4000

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -767,7 +767,7 @@ jobSubmission:
   defaultActiveDeadlineSeconds: 86400
   defaultTTLSecondsAfterFinished: 604800
   jobTTLSeconds: 2592000
-  jobLimit: 0
+  jobLimit: 4000
   # Artifact. Require phfs
   artifact:
     enabled: true


### PR DESCRIPTION
 - We already know our graphql will encounter error when phjob more than
   4000

Signed-off-by: Kent Huang <kentwelcome@gmail.com>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Fix default config

**What this PR does / why we need it**:
The workaround of graphql will encounter errors when phjobs more than 4000

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
