### PR TITLE
Prepare user home for ssh

### DIFF
--- a/chart/scripts/jupyterhub/theme/templates/groups.html
+++ b/chart/scripts/jupyterhub/theme/templates/groups.html
@@ -34,7 +34,7 @@
           Copy and paste the example below into your <code>~/.ssh/config</code>. Then replace <code>~/.ssh/id_rsa</code> with your private key location.
         </p>
         <p>
-          <pre class='snippet'><code>HOST jupyter
+          <pre class='snippet'><code>HOST {{ ssh_config.hostname }}
   User jovyan
   Hostname {{ ssh_config.hostname }}
   Port 22

--- a/chart/scripts/jupyterhub/theme/templates/home.html
+++ b/chart/scripts/jupyterhub/theme/templates/home.html
@@ -42,7 +42,7 @@
         Copy and paste the example below into your <code>~/.ssh/config</code>. Then replace <code>~/.ssh/id_rsa</code> with your private key location.
       </p>
       <p>
-        <pre class='snippet'><code>HOST jupyter
+        <pre class='snippet'><code>HOST {{ default_server.ssh_config['hostname'] }}
   User jovyan
   Hostname {{ default_server.ssh_config['hostname'] }}
   Port 22

--- a/chart/scripts/start-notebook.d/ensure_sshd.sh
+++ b/chart/scripts/start-notebook.d/ensure_sshd.sh
@@ -8,7 +8,7 @@ ensure_sshd() {
         $(command -v sshd) &
     else
         if [ $(id -u) == 0 ] ; then
-            # Install openssh server via APT 
+            # Install openssh server via APT
             if command -v apt-get &>/dev/null; then
                 echo "Installing openssh-server via APT"
                 apt-get update -q && apt-get install openssh-server --no-install-recommends -yq
@@ -28,8 +28,30 @@ ensure_sshd() {
     fi
 }
 
+prepare_user_volume() {
+  # Fix the home directory too open issue
+  if [ -e $HOME ]; then
+    chmod 755 $HOME
+  fi
+
+  # Only create .ssh when found NB_ variables
+  if [ -z ${NB_UID=+x} || -z ${NB_GID=+x} ]; then
+    return
+  fi
+
+  # Prepare default .ssh directory and setup permission
+  if [ ! -d $HOME/.ssh ]; then
+    mkdir -p $HOME/.ssh
+    chmod 700 $HOME/.ssh
+    touch $HOME/.ssh/authorized_keys
+    chmod 644 $HOME/.ssh/authorized_keys
+    chown -R $NB_UID:$NB_GID $HOME/.ssh
+  fi
+}
+
 if [ "$PRIMEHUB_START_SSH" == "true" ]; then
     ensure_sshd &
+    prepare_user_volume
 
     # Start publickey api server
     if command -v nohup &>/dev/null; then


### PR DESCRIPTION
** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

bugfix

**What this PR does / why we need it**:

Some storage provisioners create a volume in mode `777`, it is not acceptable to ssh.


**Which issue(s) this PR fixes**:

ch13675

**Special notes for your reviewer**:

In this PR we 

* chmod user volume to `755`
* if it was a regular notebook image (found `NB_UID` and `NB_GID`), we also created `.ssh` and related files with proper permissions.