### PR TITLE
Normalize the group name

### DIFF
--- a/chart/scripts/shared-space/post-finish
+++ b/chart/scripts/shared-space/post-finish
@@ -23,12 +23,10 @@ log "Upload $TUS_ID ($TUS_SIZE bytes) finished"
 info=`cat /dev/stdin`
 
 tus_id=$TUS_ID
-filename=`echo $info | jq .Upload.MetaData.filename`
-filename="${filename%\"}"
-filename="${filename#\"}"
-dirpath=`echo $info | jq .Upload.MetaData.dirpath`
-dirpath="${dirpath%\"}"
-dirpath="${dirpath#\"}"
+filename=`echo $info | jq -r .Upload.MetaData.filename`
+
+# normalize group name by lowercase and replace '-' to '_'
+dirpath=`echo $info | jq -r .Upload.MetaData.dirpath | awk 'BEGIN { FS="/" } { gsub("-", "_", $2) } { print "groups/"tolower($2)"/upload" }'`
 
 log metadata "$(echo $info | jq -c .Upload.MetaData)"
 log "tus_id $tus_id, filename $filename, dirpath $dirpath, bucket $BUCKET_NAME"

--- a/chart/scripts/shared-space/post-finish
+++ b/chart/scripts/shared-space/post-finish
@@ -25,8 +25,8 @@ info=`cat /dev/stdin`
 tus_id=$TUS_ID
 filename=`echo $info | jq -r .Upload.MetaData.filename`
 
-# normalize group name by lowercase and replace '-' to '_'
-dirpath=`echo $info | jq -r .Upload.MetaData.dirpath | awk 'BEGIN { FS="/" } { gsub("-", "_", $2) } { print "groups/"tolower($2)"/upload" }'`
+# normalize group name by lowercase and replace '_' to '-'
+dirpath=`echo $info | jq -r .Upload.MetaData.dirpath | awk 'BEGIN { FS="/" } { gsub("_", "-", $2) } { print "groups/"tolower($2)"/upload" }'`
 
 log metadata "$(echo $info | jq -c .Upload.MetaData)"
 log "tus_id $tus_id, filename $filename, dirpath $dirpath, bucket $BUCKET_NAME"


### PR DESCRIPTION
** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

bugfix

**What this PR does / why we need it**:

the group name should be normalized

**Which issue(s) this PR fixes**:

ch14583

-----


logs:

```
[tus_id:5fe38d5de374c7b8ff07dd1820763f98] Upload 5fe38d5de374c7b8ff07dd1820763f98 (3986 bytes) finished
[tus_id:5fe38d5de374c7b8ff07dd1820763f98] metadata {"dirpath":"groups/Ph-YoyY/upload","filename":"destroy-gce.sh","filetype":"text/x-sh","name":"destroy-gce.sh","relativePath":"null","type":"text/x-sh"}
[tus_id:5fe38d5de374c7b8ff07dd1820763f98] tus_id 5fe38d5de374c7b8ff07dd1820763f98, filename destroy-gce.sh, dirpath groups/ph_yoyy/upload, bucket primehub
[tus_id:5fe38d5de374c7b8ff07dd1820763f98] mv result: `/srv/tusd-data/data/5fe38d5de374c7b8ff07dd1820763f98` -> `minio/primehub/groups/ph_yoyy/upload/destroy-gce.sh` Total: 0 B, Transferred: 3.89 KiB, Speed: 385.67 KiB/s
```
