### PR TITLE
Force to add cookie path according to the appPrefix

### DIFF
--- a/chart/templates/console/deployment.yaml
+++ b/chart/templates/console/deployment.yaml
@@ -126,6 +126,11 @@ spec:
               value: {{ include "primehub.graphql.endpoint" . }}
             - name: GRAPHQL_PREFIX
               value: {{ include "primehub.graphql.path" . }}
+            - name: SHARED_GRAPHQL_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "primehub.name" . }}-graphql-shared-secret
+                  key: sharedSecret
             - name: APP_PREFIX
               value: {{ include "primehub.console.path" . }}
             {{- if or (eq .Values.primehub.mode "ee") (eq .Values.primehub.mode "deploy") }}

--- a/chart/templates/console/ingress.yaml
+++ b/chart/templates/console/ingress.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 8m
-    nginx.ingress.kubernetes.io/proxy-cookie-path: / /console/
     nginx.ingress.kubernetes.io/app-root: /console/g
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Because console knows the appPrefix. It should use cookie path according to appPrefix settings instead of rewriting the cookie path on the nginx side.