### PR TITLE
NetworkPolicy for jupyter pods egress allows to phapps

### DIFF
--- a/chart/templates/jupyterhub/phapps-netpol.yaml
+++ b/chart/templates/jupyterhub/phapps-netpol.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: jupyter-phapp
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: singleuser-ph-applications
+spec:
+  podSelector:
+    matchLabels:
+      app: jupyterhub
+      component: singleuser-server
+      release: {{ .Release.Name }}
+  # singleuser-server --> primehub-app:*
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app: primehub-app
+  policyTypes:
+  - Egress


### PR DESCRIPTION

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

feature added

**What this PR does / why we need it**:

add egress rules to pods with `component-singleuser-server` label

**Which issue(s) this PR fixes**:

ch15908
