### PR TITLE
Fix NotebooksAdmin URL, spawner page not showing issue

### DIFF
--- a/tests/features/003-admin-notebooks-admin.feature
+++ b/tests/features/003-admin-notebooks-admin.feature
@@ -1,4 +1,4 @@
-@wip @admin-user
+@admin-user
 Feature: Notebooks Admin
   Basic tests
 
@@ -10,7 +10,8 @@ Feature: Notebooks Admin
     Then I am on the PrimeHub console "Home" page
     When I choose "Notebooks" in sidebar menu
     Then I am on the PrimeHub console "Notebooks" page
-    When I go to the spawner page
+    When I get the iframe object
+    And I go to the spawner page
     And I wait for 2.0 seconds
     And I choose instance type with name "test-instance-type"
     And I choose image with name "test-image"
@@ -31,6 +32,7 @@ Feature: Notebooks Admin
     Then I am on the PrimeHub console "Home" page
     When I choose "Notebooks" in sidebar menu
     Then I am on the PrimeHub console "Notebooks" page
+    When I get the iframe object
     And I go to the spawner page
     When I choose "Logout" in top-right menu
     Then I am on login page

--- a/tests/features/stepDefinitions/general.js
+++ b/tests/features/stepDefinitions/general.js
@@ -122,7 +122,7 @@ defineStep("I switch to {string} tab", async function(tabname) {
     'Notebooks': `-${this.E2E_SUFFIX}/hub`,
     'JupyterLab': `/user/${this.USERNAME}/lab`,
     'JobDetail': `-${this.E2E_SUFFIX}/job/`,
-    'NotebooksAdmin': 'console/cms/default/jupyterhub'
+    'NotebooksAdmin': 'console/cms/jupyterhub'
   };
   let pages, targetPage;
   if (tabname in urlMap) tabname = urlMap[tabname];


### PR DESCRIPTION
Signed-off-by: Eric Chang <ericcc@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [X] Ensure you have added or ran the appropriate tests for your PR.
- [X] DCO signed

**What type of PR is this?**
Hotfix
**What this PR does / why we need it**:
To correct NotebooksAdmin URL
Add verification for page to show up

**Which issue(s) this PR fixes**:
NotebooksAdmin URL
Spawner page not showing issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
```
