### PR TITLE
[Fix] ch18029 fix PRIMEHUB_AIRGAPPED flag not set when first install

### DIFF
--- a/install/primehub-install
+++ b/install/primehub-install
@@ -626,6 +626,7 @@ prepare_primehub_env() {
     export PRIMEHUB_NAMESPACE
     export PH_PASSWORD
     export KC_PASSWORD
+    export PRIMEHUB_AIRGAPPED=${PRIMEHUB_AIRGAPPED}
 
     # microk8s-hostpath storage class support both RWO and RWX
     if [[ "${PRIMEHUB_STORAGE_CLASS}" == 'microk8s-hostpath' ]]; then


### PR DESCRIPTION
Signed-off-by: Kent Huang <kentwelcome@gmail.com>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug fix

**What this PR does / why we need it**:
Airgap flag not be enabled when run the primehub install first time

**Which issue(s) this PR fixes**:'
ch18029

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
