### PR TITLE
[Fix] ch19067 minio persistence sc should come from .env

### DIFF
--- a/install/helmfiles/primehub/primehub.yaml.gotmpl
+++ b/install/helmfiles/primehub/primehub.yaml.gotmpl
@@ -179,6 +179,10 @@ minio:
     enabled: true
     projectId: {{$MINIO_GCSGATEWAY_PROJECT_ID | quote}}
     gcsKeyJson: {{$MINIO_GCSGATEWAY_GCS_KEY_JSON | quote}}
+{{- else }}
+minio:
+  persistence:
+    storageClass: {{ $PRIMEHUB_STORAGE_CLASS }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Signed-off-by: Kent Huang <kentwelcome@gmail.com>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug fix

**What this PR does / why we need it**:
minio persistence storageClass should come from PRIMEHUB_STORAGE_CLASS

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
