### PR TITLE
[Feature] ch18729 add option to disable createBucket post job of minio

### DIFF
--- a/chart/templates/minio/_helper_create_bucket.txt
+++ b/chart/templates/minio/_helper_create_bucket.txt
@@ -77,5 +77,9 @@ createBucket() {
 scheme=http
 connectToMinio $scheme
 
-createBucket {{ .Values.store.bucket }} none false
+{{- if .Values.store.createBucket.enabled }}
+createBucket {{ .Values.store.bucket }} {{ .Values.store.createBucket.policy }} {{ .Values.store.createBucket.purge }}
+{{- else }}
+echo "Skip createBucket, bucket '{{ .Values.store.bucket }}' already exists."
+{{- end }}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -849,6 +849,10 @@ store:
   accessKey: "AKIAIOSFODNN7EXAMPLE"
   secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   bucket: "primehub"
+  createBucket:
+    enabled: true
+    policy: none
+    purge: false
 
   phfs:
     enabled: true

--- a/install/primehub-install
+++ b/install/primehub-install
@@ -1151,7 +1151,7 @@ destroy::primehub() {
   backup_config
 
   info "[Delete] primehub helm"
-  ns=$(helm ls -A -f primehub -o json | jq -r '.[0].namespace')
+  ns=$(helm ls -A -a -f primehub -o json | jq -r '.[0].namespace')
   helm uninstall -n $ns primehub
 
   info "[Delete] Primehub CRD"


### PR DESCRIPTION
Signed-off-by: Kent Huang <kentwelcome@gmail.com>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
When using S3 as PrimeHub store's storage backend, the bucket will be created before installing the minio. 
We don't need to use a post-job script to create the bucket. 

**Which issue(s) this PR fixes**:
ch18729

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
