### PR TITLE
[Fix] ch20648 primehub-install version won't display alpha release version

### DIFF
--- a/install/primehub-install
+++ b/install/primehub-install
@@ -1208,17 +1208,17 @@ show_versions() {
   info "[Available] PrimeHub Versions:"
   if [[ "$yq_version" =~ ^4\.[0-9]+\.[0-9]+$ ]]; then
     # For YQ 4
-    curl -s ${PRIMEHUB_HELM_CHART} | yq e '.entries.primehub[].appVersion' - | grep -v "\-rc"
+    curl -s ${PRIMEHUB_HELM_CHART} | yq e '.entries.primehub[].appVersion' - | grep 'v\d*\.\d*\.\d*$'
     if [[ ${SHOW_RC_VERSION} == true ]]; then
       warn "[Available] PrimeHub Beta Versions:"
-      curl -s ${PRIMEHUB_HELM_CHART} | yq e '.entries.primehub[].appVersion' - | grep "\-rc"
+      curl -s ${PRIMEHUB_HELM_CHART} | yq e '.entries.primehub[].appVersion' - | grep 'v\d*\.\d*\.\d*-rc.*$'
     fi
   else
     # For YQ 2 or 3
-    curl -s ${PRIMEHUB_HELM_CHART} | yq r - 'entries.primehub[*].appVersion' | grep -v "\-rc"
+    curl -s ${PRIMEHUB_HELM_CHART} | yq r - 'entries.primehub[*].appVersion' | grep 'v\d*\.\d*\.\d*$'
     if [[ ${SHOW_RC_VERSION} == true ]]; then
       warn "[Available] PrimeHub Beta Versions:"
-      curl -s ${PRIMEHUB_HELM_CHART} | yq r - 'entries.primehub[*].appVersion' | grep "\-rc"
+      curl -s ${PRIMEHUB_HELM_CHART} | yq r - 'entries.primehub[*].appVersion' | grep 'v\d*\.\d*\.\d*-rc.*$'
     fi
   fi
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug fix

**What this PR does / why we need it**:
primehub-install version command won't show alpha release version.

**Which issue(s) this PR fixes**:
ch20648

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
