### PR TITLE
fix(jupyterhub): always same created time

### DIFF
--- a/chart/scripts/jupyterhub/config/jupyterhub_profiles.py
+++ b/chart/scripts/jupyterhub/config/jupyterhub_profiles.py
@@ -938,7 +938,7 @@ class PrimeHubSpawner(KubeSpawner):
     _default_instance_type = None
     _autolaunch = None
     started_at = None
-    created_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    created_time = None
     launch_image = ""
     instance_type = ""
 
@@ -1263,6 +1263,7 @@ class PrimeHubSpawner(KubeSpawner):
         try:
             self.instance_type = formdata.get('instance_type_display_name')[0]
             self.launch_image = formdata.get('image_display_name')[0]
+            self.created_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         except:
             self.instance_type = '<unknown>'
             self.launch_image = '<unknown>'


### PR DESCRIPTION
## Screenshots

1.
<img width="1191" alt="截圖 2021-10-01 上午9 12 39" src="https://user-images.githubusercontent.com/10325111/135550711-eafa97ce-e4b0-4fdd-ba13-d6742296f481.png">

2.

<img width="1195" alt="截圖 2021-10-01 上午9 13 19" src="https://user-images.githubusercontent.com/10325111/135550766-b2100c34-abad-4fb2-9150-1542495d7867.png">

Signed-off-by: Jie Peng <im@jiepeng.me>

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed