### PR TITLE
fix(notebook): text overflow

### DIFF
--- a/chart/scripts/jupyterhub/theme/static/css/primehub/primehub.css
+++ b/chart/scripts/jupyterhub/theme/static/css/primehub/primehub.css
@@ -194,6 +194,12 @@ label.disabled {
   transform: translate(-50%, -50%);
 }
 
+.name-col {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 @-webkit-keyframes glow {
   0% {
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0), 0 -1px 2px 0px rgba(0, 0, 0, 0);

--- a/chart/scripts/jupyterhub/theme/static/css/primehub/spawner.css
+++ b/chart/scripts/jupyterhub/theme/static/css/primehub/spawner.css
@@ -163,3 +163,22 @@
   }
 }
 
+.image-name {
+   display: flex;
+   gap: 4px;
+   align-items: center;
+   margin-bottom: 8px;
+}
+
+.image-name > p {
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 0;
+}
+
+.image-description  {
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/chart/scripts/jupyterhub/theme/static/css/primehub/spawner.css
+++ b/chart/scripts/jupyterhub/theme/static/css/primehub/spawner.css
@@ -163,21 +163,21 @@
   }
 }
 
-.image-name {
+.image-name, .instance-type-name {
    display: flex;
    gap: 4px;
    align-items: center;
    margin-bottom: 8px;
 }
 
-.image-name > p {
-  max-width: 400px;
+.image-name > p, .instance-type-name > p {
+  max-width: 380px;
   overflow: hidden;
   text-overflow: ellipsis;
   margin-bottom: 0;
 }
 
-.image-description  {
+.image-description, .instance-type-description  {
   max-width: 400px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/chart/scripts/jupyterhub/theme/templates/spawn.html
+++ b/chart/scripts/jupyterhub/theme/templates/spawn.html
@@ -198,10 +198,12 @@
             <input type="radio" name="image" data-image-name="{{ displayName }}" id="image-item-{{index}}" data-index="{{index}}" value="{{name}}" />
         </div>
         <div class="col-md-11">
-            <strong>{{displayName}} <i class="fa fa-info-circle" aria-hidden="true" data-toggle="tooltip" data-placement="right" title="{{typeLabel}}"></i></strong>
+          <div class="image-name">
+            <p style="font-weight: 700">{{displayName}}</p> <i class="fa fa-info-circle" aria-hidden="true" data-toggle="tooltip" data-placement="right" title="{{typeLabel}}"></i>
+          </div>
             {{#description}}
-            <p>{{description}}</p>
-            {{/description}}
+            <p class="image-description">{{description}}</p>
+          {{/description}}
         </div>
     </label>
     {{/.}}

--- a/chart/scripts/jupyterhub/theme/templates/spawn.html
+++ b/chart/scripts/jupyterhub/theme/templates/spawn.html
@@ -182,9 +182,11 @@
             <input type="radio" name="instance_type" data-display-name="{{ displayName }}" id="instance_type-item-{{index}}" data-index="{{index}}" value="{{name}}" />
         </div>
         <div class="col-md-11">
-            <strong>{{displayName}} <i class="fa fa-info-circle" aria-hidden="true" data-toggle="tooltip" data-placement="right" title="{{resourceLimits}}" id="instance_type-item-info-icon-{{index}}"></i></strong>
+            <div class="instance-type-name">
+              <p style="font-weight: 700">{{displayName}}</p><i class="fa fa-info-circle" aria-hidden="true" data-toggle="tooltip" data-placement="right" title="{{resourceLimits}}" id="instance_type-item-info-icon-{{index}}"></i>
+            </div>
             {{#description}}
-            <p>{{description}}</p>
+              <p class="instance-type-description">{{description}}</p>
             {{/description}}
         </div>
     </label>
@@ -199,9 +201,9 @@
         </div>
         <div class="col-md-11">
           <div class="image-name">
-            <p style="font-weight: 700">{{displayName}}</p> <i class="fa fa-info-circle" aria-hidden="true" data-toggle="tooltip" data-placement="right" title="{{typeLabel}}"></i>
+            <p style="font-weight: 700">{{displayName}}</p><i class="fa fa-info-circle" aria-hidden="true" data-toggle="tooltip" data-placement="right" title="{{typeLabel}}"></i>
           </div>
-            {{#description}}
+          {{#description}}
             <p class="image-description">{{description}}</p>
           {{/description}}
         </div>


### PR DESCRIPTION
## Screenshots

### Client
<img width="1141" alt="截圖 2021-10-05 下午3 10 04" src="https://user-images.githubusercontent.com/10325111/135979381-fc768880-07fd-4f3c-bc2a-dbb508a52789.png">

### Admin
<img width="1433" alt="截圖 2021-10-05 下午3 28 23" src="https://user-images.githubusercontent.com/10325111/135979405-c33de2df-92ff-4389-8e6d-7b7e0ddd675e.png">

## Description

- Fixed client & admin notebook text fields overflow

> **Note: Others UI fixing at `primehub-console`, I will create another PR.**

Signed-off-by: Jie Peng <im@jiepeng.me>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed