### PR TITLE
[Feature] sc20773 Update primehub-install script for 1-click aws prim…

### DIFF
--- a/install/primehub-install
+++ b/install/primehub-install
@@ -39,7 +39,7 @@ LOGS_TAIL=10000
 HELM_TIMEOUT=1000
 DOMAIN_CHECK=true
 DISK_SIZE_CHECK=true
-SHOW_RC_VERSION=false
+SHOW_VERSION=release
 
 MINIMAL_CPU_REQUEST=3700 # 4 CPU
 MINIMAL_MEM_REQUEST=8388608 # 8Gi Mem
@@ -185,8 +185,9 @@ search_helm_release() {
 infuseai_repo_update() {
   if [[ "$(helm repo list | grep infuseai)" == "" ]]; then
     helm repo add infuseai https://charts.infuseai.io
-    helm repo update
   fi
+  info "[Update] helm repo"
+  helm repo update
 }
 
 check::microk8s::snap() {
@@ -1250,24 +1251,35 @@ show_versions() {
     grep_options='-P'
   fi
 
-  info "[Available] PrimeHub Versions:"
   if [[ "$yq_version" =~ ^4\.[0-9]+\.[0-9]+$ ]]; then
     # For YQ 4
-    curl -s ${PRIMEHUB_HELM_CHART} | yq e '.entries.primehub[].appVersion' - | grep ${grep_options} 'v\d*\.\d*\.\d*$'
-    if [[ ${SHOW_RC_VERSION} == true ]]; then
+    if [[ ${SHOW_VERSION} == 'rc' ]]; then
       warn "[Available] PrimeHub Beta Versions:"
       curl -s ${PRIMEHUB_HELM_CHART} | yq e '.entries.primehub[].appVersion' - | grep ${grep_options} 'v\d*\.\d*\.\d*-rc.*$'
+    elif [[ ${SHOW_VERSION} == 'aws' ]]; then
+      warn "[Available] PrimeHub AWS Versions:"
+      curl -s ${PRIMEHUB_HELM_CHART} | yq e '.entries.primehub[].appVersion' - | grep ${grep_options} 'v\d*\.\d*\.\d*-aws.*$'
+    else
+      info "[Available] PrimeHub Versions:"
+      curl -s ${PRIMEHUB_HELM_CHART} | yq e '.entries.primehub[].appVersion' - | grep ${grep_options} 'v\d*\.\d*\.\d*$'
     fi
   else
     # For YQ 2 or 3
-    curl -s ${PRIMEHUB_HELM_CHART} | yq r - 'entries.primehub[*].appVersion' | grep ${grep_options} 'v\d*\.\d*\.\d*$'
-    if [[ ${SHOW_RC_VERSION} == true ]]; then
+    if [[ ${SHOW_VERSION} == 'rc' ]]; then
       warn "[Available] PrimeHub Beta Versions:"
       curl -s ${PRIMEHUB_HELM_CHART} | yq r - 'entries.primehub[*].appVersion' | grep ${grep_options} 'v\d*\.\d*\.\d*-rc.*$'
+    elif [[ ${SHOW_VERSION} == 'aws' ]]; then
+      warn "[Available] PrimeHub AWS Versions:"
+      curl -s ${PRIMEHUB_HELM_CHART} | yq r - 'entries.primehub[*].appVersion' | grep ${grep_options} 'v\d*\.\d*\.\d*-aws.*$'
+    else
+      info "[Available] PrimeHub Versions:"
+      curl -s ${PRIMEHUB_HELM_CHART} | yq r - 'entries.primehub[*].appVersion' | grep ${grep_options} 'v\d*\.\d*\.\d*$'
     fi
   fi
+}
 
-
+primehub_aws_latest_version() {
+  curl -s ${PRIMEHUB_HELM_CHART} | grep 'appVersion: .*-aws' | sed 's/.*appVersion: //' | head -1
 }
 
 verify_minimal_resources() {
@@ -1577,7 +1589,11 @@ main() {
         DISK_SIZE_CHECK=false
       ;;
       --beta)
-        SHOW_RC_VERSION=true
+        SHOW_VERSION=rc
+      ;;
+      --aws)
+        SHOW_VERSION=aws
+        PRIMEHUB_VERSION=$(primehub_aws_latest_version)
       ;;
       --logs-path|--log-path)
         shift

--- a/install/primehub-install
+++ b/install/primehub-install
@@ -103,7 +103,7 @@ USAGE:
   $SELF destroy primehub                         : Uninstall PrimeHub
   $SELF destroy prometheus                       : Uninstall Prometheus
   $SELF license                                  : Show the license of PrimeHub
-  $SELF version [--beta]                         : Show the default and available PrimeHub versions
+  $SELF version [--beta] [--aws]                 : Show the default and available PrimeHub versions
   $SELF apply-license [--license-path path]      : Apply the license of PrimeHub
   $SELF usage                                    : Show the resource usage of the k8s environment
   $SELF required-bin                             : Install the required binaries manually
@@ -127,6 +127,7 @@ Options:
   --helm-timeout      <timeout-duration>         : Timeout of helm install          (Default: 1000)
   --skip-domain-check                            : Skip the domain name check
   --skip-disk-space-check                        : Skip the disk space check when install singlenode k8s
+  --aws                                          : Set the latest PrimeHub AWS version as default verion
 EOF
 }
 


### PR DESCRIPTION

Signed-off-by: Kent Huang <kentwelcome@gmail.com>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
 - Add --aws option when show version will show 1-click aws primehub
   versions
 - Enforce to run helm repo update before diff, install and upgrade
 - When using --aws option, the PrimeHub version will auto assign to
   latest 1-click aws primehub version (ex: v3.8.0-aws.1)


**Which issue(s) this PR fixes**:
sc-20773

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
