### PR TITLE
Work around for microk8s enable failed

### DIFF
--- a/install/primehub-install
+++ b/install/primehub-install
@@ -3,6 +3,10 @@ set -eo pipefail
 IFS=$'\n\t '
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
 export PATH=${PATH}:~/bin
 K9S_VERSION=v0.21.9
 KUBECTL_VERSION=v1.21.3


### PR DESCRIPTION
Got this error when `enable`

```
ubuntu@ip-10-40-0-11:~$ microk8s enable
Traceback (most recent call last):
  File "/snap/microk8s/2546/scripts/wrappers/enable.py", line 43, in <module>
    enable(prog_name="microk8s enable")
  File "/snap/microk8s/2546/usr/lib/python3/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/snap/microk8s/2546/usr/lib/python3/dist-packages/click/core.py", line 676, in main
    _verify_python3_env()
  File "/snap/microk8s/2546/usr/lib/python3/dist-packages/click/_unicodefun.py", line 118, in _verify_python3_env
    'for mitigation steps.' + extra)
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Consult http://click.pocoo.org/python3/for mitigation steps.

This system supports the C.UTF-8 locale which is recommended.
You might be able to resolve your issue by exporting the
following environment variables:

    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8
ubuntu@ip-10-40-0-11:~$
```

Add the envs to the script make it working