### PR TITLE
[Fix] sc-22580 disable servicelb when setup k3d

### DIFF
--- a/ci/k3d/setup-k3d.sh
+++ b/ci/k3d/setup-k3d.sh
@@ -28,7 +28,7 @@ k3d version
 # Create k3d
 # https://github.com/rancher/k3d/issues/206
 mkdir -p /tmp/k3d/kubelet/pods
-k3d cluster create ${CLUSTER_NAME} -v /tmp/k3d/kubelet/pods:/var/lib/kubelet/pods:shared --image rancher/k3s:${K8S_VERSION} --k3s-server-arg '--disable=traefik' --k3s-server-arg '--disable-network-policy' --wait --kubeconfig-update-default
+k3d cluster create ${CLUSTER_NAME} -v /tmp/k3d/kubelet/pods:/var/lib/kubelet/pods:shared --image rancher/k3s:${K8S_VERSION} --k3s-server-arg '--disable=traefik' --k3s-server-arg  '--disable=servicelb' --k3s-server-arg '--disable-network-policy' --wait --kubeconfig-update-default
 kubectl config view
 
 echo "waiting for nodes ready"


### PR DESCRIPTION
Signed-off-by: Kent Huang <kentwelcome@gmail.com>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Fix CI randomly failed issue

**What this PR does / why we need it**:
 - Disable k3d servicelb feature to bypass the random CI fail issue

**Which issue(s) this PR fixes**:
sc-22580

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
