### PR TITLE
fix: show GPU resource

### DIFF
--- a/install/primehub-install
+++ b/install/primehub-install
@@ -1328,7 +1328,7 @@ verify_minimal_resources() {
         fi
       elif echo $resource | grep memory > /dev/null; then
         memory=$(echo $resource | grep memory | sed 's/[^0-9]*//g')
-      elif echo $resource | grep 'nvidia.com/gpu '> /dev/null; then
+      elif echo $resource | grep 'nvidia.com/gpu'> /dev/null; then
         gpu=$(echo $resource | grep 'nvidia.com/gpu'; | sed 's/[^0-9]*//g')
       fi
     done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Fix the GPU resource core checking.


**What this PR does / why we need it**:
kubectl describe node <node_name> | grep -E "^Allocatable" -A7 | grep 'nvidia.com/gpu'
 **nvidia.com/gpu**:     8

Original:
```
grep 'nvidia.com/gpu '
```

Should do 
```
grep 'nvidia.com/gpu
```

**Which issue(s) this PR fixes**:
Fix the gpu core grep syntax by space removal.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
