### PR TITLE
fix: show GPU resource, unnecessary semicolon

### DIFF
--- a/install/primehub-install
+++ b/install/primehub-install
@@ -1329,7 +1329,7 @@ verify_minimal_resources() {
       elif echo $resource | grep memory > /dev/null; then
         memory=$(echo $resource | grep memory | sed 's/[^0-9]*//g')
       elif echo $resource | grep 'nvidia.com/gpu'> /dev/null; then
-        gpu=$(echo $resource | grep 'nvidia.com/gpu'; | sed 's/[^0-9]*//g')
+        gpu=$(echo $resource | grep 'nvidia.com/gpu' | sed 's/[^0-9]*//g')
       fi
     done
     node_count=$((node_count + 1))


### PR DESCRIPTION
Signed-off-by: Jimmy Liao <jimmyliao@jimmyliao.net>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Remove unnecessary semicolon on GPU resource grep

**What this PR does / why we need it**:

Before:
```
gpu=$(echo $resource | grep 'nvidia.com/gpu'; | sed 's/[^0-9]*//g')
-bash: command substitution: line 39: syntax error near unexpected token `|'
-bash: command substitution: line 39: `echo $resource | grep 'nvidia.com/gpu'; | sed 's/[^0-9]*//g')'
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
