### PR TITLE
Support airgap image prefix for primehub-controller

### DIFF
--- a/chart/templates/controller/configmap.yaml
+++ b/chart/templates/controller/configmap.yaml
@@ -12,6 +12,7 @@ metadata:
 data:
   config.yaml: |-
     primehubUrl: {{ include "primehub.url" . }}
+    imagePrefix: {{ .Values.controller.airgap.imagePrefix }}
     phfsEnabled: {{ include "primehub.phfs.enabled" . }}
     phfsPVC: {{ include "primehub.store.pvcName" . }}
     ingress:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -737,6 +737,9 @@ jupyterhub:
 controller:
   replicaCount: 1
 
+  airgap:
+    imagePrefix: ""
+
   image:
     repository: infuseai/primehub-controller
     tag: latest

--- a/install/helmfiles/primehub/primehub.yaml.gotmpl
+++ b/install/helmfiles/primehub/primehub.yaml.gotmpl
@@ -209,3 +209,9 @@ grafana:
 rclone:
   kubeletPath: /var/snap/microk8s/common/var/lib/kubelet
 {{- end }}
+
+{{if env "PRIMEHUB_AIRGAPPED_IMAGE_PREFIX" }}
+controller:
+  airgap:
+    imagePrefix: {{ env "PRIMEHUB_AIRGAPPED_IMAGE_PREFIX" }}
+{{end}}


### PR DESCRIPTION

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

enhancement

**What this PR does / why we need it**:

support air-gap image prefix for ph-controller

**Which issue(s) this PR fixes**:

sc-24401



**Special notes for your reviewer**:

1. introduce the new settings to `values.yaml`

```yaml
 controller:
   airgap:
     imagePrefix: ""
```
2. the value would be overridden by `PRIMEHUB_AIRGAPPED_IMAGE_PREFIX` env from helmfile
