### PR TITLE
[Bug][PrimeHub] awk wrong message

### DIFF
--- a/install/primehub-install
+++ b/install/primehub-install
@@ -1067,7 +1067,7 @@ install::primehub() {
     # if kube-apiserver is not running on 6443, override corresponding values in primehub.yaml
     local kube_api_port=$(kubectl get services kubernetes -o json | jq -r '.spec.ports[0].targetPort')
     if [[ "$kube_api_port" != "" ]] && [[ "$kube_api_port" != "6443" ]]; then
-      local yq_version=$(yq -V| awk '{print $3}')
+      local yq_version=$(yq --version | egrep -o "([0-9]{1,}\.)+[0-9]{1,}")
       if [[ "$yq_version" =~ ^4\.[0-9]+\.[0-9]+$ ]]; then
         yq -i e ".sshBastionServer.netpol.kubeApiPort = $kube_api_port" $PRIMEHUB_CONFIG
       else


### PR DESCRIPTION
When we run the command line `yq -V`, we get the result `yq (https://github.com/mikefarah/yq/) version 4.23.1`. We awk the third word, but we need to get the version number, the fourth word. Fix the bug to make sure that the script is corrected.

Signed-off-by: simonliu1 <simonliu@infuseai.io>

<!--  Thanks for sending a pull request! Here are some check items for you: -->

** PR checklist **

- [ X ] Ensure you have added or ran the appropriate tests for your PR.
- [ X ] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Fix the installation script bug.
```
