### PR TITLE
Tuning ulimit vaule

### DIFF
--- a/chart/scripts/start-notebook.d/ulimit.sh
+++ b/chart/scripts/start-notebook.d/ulimit.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-ulimit -n 4096 # Maximum number of open file descriptors
-ulimit -u 2048 # Maximum number of processes available to a single user
+ulimit -n 65535 # Maximum number of open file descriptors
+ulimit -u 65535 # Maximum number of processes available to a single user


### PR DESCRIPTION
Signed-off-by: Dennis Huang dennishuang@infuseai.io

Tuning ulimit vaule higher to prevent "Resource temporarily unavailable" issue

**PR checklist**
- [X] Ensure you have added or ran the appropriate tests for your PR.
- [X] DCO signed

**What type of PR is this?**
Change initial vaule of ulimit for each PrimeHub user

**What this PR does / why we need it:**
Tuning ulimit vaule higher so user won't hit ulimit hard limit.

**Which issue(s) this PR fixes:**
Prevent "Resource temporarily unavailable" issue in user jupyter notebook pod.

**Special notes for your reviewer:**

1. Change open file number to 65535
2. Change processes number for a single user to 65535

**Does this PR introduce a user-facing change?:**
NONE






















