### PR TITLE
[Airgapped env.] Add the airgapped tag into install script.

### DIFF
--- a/install/primehub-install
+++ b/install/primehub-install
@@ -30,6 +30,7 @@ PRIMEHUB_CHART_PATH=
 PRIMEHUB_MODE='ee'
 PRIMEHUB_FEATURE_SSH_BASTION_SERVER=false
 PRIMEHUB_AIRGAPPED=
+PRIMEHUB_AIRGAPPED_IMAGE_PREFIX=
 LICENSE_PATH=
 
 PROMETHEUS_CHART="stable/prometheus-operator"
@@ -147,6 +148,7 @@ Options:
   --skip-domain-check                            : Skip the domain name check
   --skip-disk-space-check                        : Skip the disk space check when install singlenode k8s
   --aws                                          : Set the latest PrimeHub AWS version as default verion
+  --airgap                                       : Install the PrimeHub from private repository platform.
 EOF
 }
 
@@ -644,6 +646,7 @@ init_env() {
     PH_PASSWORD
 
     PRIMEHUB_AIRGAPPED
+    PRIMEHUB_AIRGAPPED_IMAGE_PREFIX
 
     PRIMEHUB_CONTROLLER_CUSTOM_IMAGE_REGISTRY_ENDPOINT
     PRIMEHUB_CONTROLLER_CUSTOM_IMAGE_REGISTRY_USERNAME
@@ -691,6 +694,9 @@ prepare_primehub_env() {
     prepare_env_varible PRIMEHUB_DOMAIN || (usage_PRIMEHUB_DOMAIN; exit 1)
     prepare_env_varible KC_PASSWORD || (info "Will auto generate KC_PASSWORD for you."; true)
     prepare_env_varible PH_PASSWORD || (info "Will auto generate PH_PASSWORD for you."; true)
+    if [[ "$PRIMEHUB_AIRGAPPED" == "true" ]]; then
+      prepare_env_varible PRIMEHUB_AIRGAPPED_IMAGE_PREFIX || (info "Will pull the docker images from Dockerhub."; true)
+    fi
     if [[ "${PRIMEHUB_STORAGE_CLASS}" == "" ]]; then
       info "[Available] K8S StorageClass"
       kubectl get storageclass
@@ -728,6 +734,7 @@ prepare_primehub_env() {
     export PH_PASSWORD
     export KC_PASSWORD
     export PRIMEHUB_AIRGAPPED=${PRIMEHUB_AIRGAPPED}
+    export PRIMEHUB_AIRGAPPED_IMAGE_PREFIX=${PRIMEHUB_AIRGAPPED_IMAGE_PREFIX}
 
     # microk8s-hostpath storage class support both RWO and RWX
     if [[ "${PRIMEHUB_STORAGE_CLASS}" == 'microk8s-hostpath' ]]; then


### PR DESCRIPTION
WHY:
1. Need to configure the PRIMEHUB_AIRGAPPED_IMAGE_PREFIX in env file. 
HOW:
1. Configure the variable when PRIMEHUB_AIRGAPPED is true.

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [ X ] Ensure you have added or ran the appropriate tests for your PR.
- [ X ] DCO signed

**What type of PR is this?**
feature

**What this PR does / why we need it**:
use Github Repo to install PrimeHub in air-gapped environment.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
in env file, we will have the variable like this:
```
PRIMEHUB_AIRGAPPED=true
PRIMEHUB_AIRGAPPED_IMAGE_PREFIX=<airgapped-platform-url>
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
- Add the air-gapped tag into install script. 
```
